### PR TITLE
fix: reduce number of retries to 5

### DIFF
--- a/helm/syft-generator-chart/templates/tekton/syft-generation-task.yaml
+++ b/helm/syft-generator-chart/templates/tekton/syft-generation-task.yaml
@@ -21,7 +21,7 @@ spec:
       description: "Container image to generate manifest for"
     - name: retry-count
       type: string
-      default: "30"
+      default: "5"
     - name: retry-delay
       type: string
       default: "1"


### PR DESCRIPTION
Reducing the number of retries from 30 to 5, as the exponential back-off meant it the pod 20+ minutes to fail.