### PR TITLE
fix: remove oomkilled generation when it happens before retry

### DIFF
--- a/src/main/java/org/jboss/sbomer/syft/generator/core/service/GeneratorService.java
+++ b/src/main/java/org/jboss/sbomer/syft/generator/core/service/GeneratorService.java
@@ -77,6 +77,7 @@ public class GeneratorService implements GenerationOrchestrator {
 
         // If we hit OOM, we retry with more resources
         if (status == GenerationStatus.FAILED && "OOMKilled".equals(reason)) {
+            executor.cleanupGeneration(generationId);
             handleOomRetry(generationId);
             return; // Stop here. Method will do its own notification if needed
         }


### PR DESCRIPTION
I forgot this line, it's important to remove the oomkilled pod before retrying once more