### PR TITLE
Add image registry authentication by secret to the Syft Task

### DIFF
--- a/hack/test-syft-image-gen.sh
+++ b/hack/test-syft-image-gen.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 
-# Usage: ./test-syft-image-gen.sh [API_URL] [IMAGE_TO_SCAN]
+# Usage: ./test-image-gen.sh [API_URL] [IMAGE_URL]
 
 # Configuration
 API_URL="${1:-http://localhost:8080}"
-IMAGE="${2:-quay.io/pct-security/mequal:latest}"
+IMAGE_URL="${2:-quay.io/pct-security/mequal:latest}"
 ENDPOINT="${API_URL}/api/v1/generations"
 
-echo "Target: $ENDPOINT"
-echo "Image:  $IMAGE"
+echo "Target API: $ENDPOINT"
+echo "Image:      $IMAGE_URL"
 
 # Construct JSON Payload
 PAYLOAD=$(cat <<EOF
@@ -17,7 +17,7 @@ PAYLOAD=$(cat <<EOF
     {
       "target": {
         "type": "CONTAINER_IMAGE",
-        "identifier": "${IMAGE}"
+        "identifier": "${IMAGE_URL}"
       }
     }
   ]
@@ -60,11 +60,11 @@ if [[ "$HTTP_STATUS" == "202" ]]; then
         sleep 2
 
         echo "--- Initial Status ---"
-        curl -s "$API_URL/api/v1/admin/requests/$ID/generations" | jq .
+        curl -s "$API_URL/api/v1/requests/$ID/generations" | jq .
 
         echo ""
         echo "Status can be tracked via the command below:"
-        echo "curl -s $API_URL/api/v1/admin/requests/$ID/generations | jq"
+        echo "curl -s $API_URL/api/v1/requests/$ID/generations | jq"
     else
         echo "Response: $HTTP_BODY"
     fi

--- a/helm/syft-generator-chart/templates/tekton/syft-generation-task.yaml
+++ b/helm/syft-generator-chart/templates/tekton/syft-generation-task.yaml
@@ -52,7 +52,7 @@ spec:
         - name: RETRY_MAX_DELAY
           value: "$(params.retry-max-delay)"
         - name: DOCKER_CONFIG
-          value: "/tekton/creds/.docker"
+          value: "/opt/docker-config"
       resources:
         requests:
           cpu: 50m
@@ -120,7 +120,7 @@ spec:
           name: shared
         - mountPath: /opt/otel
           name: otel-helpers
-        - mountPath: /tekton/creds/.docker
+        - mountPath: /opt/docker-config
           name: docker-config
 
     - name: generate
@@ -151,7 +151,7 @@ spec:
         - name: SYFT_LOG_LEVEL
           value: "info"
         - name: DOCKER_CONFIG
-          value: "/tekton/creds/.docker"
+          value: "/opt/docker-config"
       script: |
         #!/usr/bin/env bash
         set -Eeuo pipefail
@@ -182,7 +182,7 @@ spec:
           name: shared
         - mountPath: /opt/otel
           name: otel-helpers
-        - mountPath: /tekton/creds/.docker
+        - mountPath: /opt/docker-config
           name: docker-config
 
     - name: upload

--- a/helm/syft-generator-chart/templates/tekton/syft-generation-task.yaml
+++ b/helm/syft-generator-chart/templates/tekton/syft-generation-task.yaml
@@ -51,6 +51,8 @@ spec:
           value: "$(params.retry-delay)"
         - name: RETRY_MAX_DELAY
           value: "$(params.retry-max-delay)"
+        - name: DOCKER_CONFIG
+          value: "/tekton/creds/.docker"
       resources:
         requests:
           cpu: 50m
@@ -72,7 +74,6 @@ spec:
         echo "Fetching raw manifest for $(params.image)"
         fetch_raw() {
           skopeo inspect --no-tags --raw docker://$(params.image) \
-            --authfile=/tekton/creds/.docker/config.json \
             > "$(workspaces.data.path)/raw.json"
         }
         retry "skopeo-inspect-raw" fetch_raw
@@ -80,7 +81,6 @@ spec:
         echo "Inspecting $(params.image)"
         fetch_inspect() {
           skopeo inspect --no-tags docker://$(params.image) \
-            --authfile=/tekton/creds/.docker/config.json \
             > "$(workspaces.data.path)/image.json"
         }
         retry "skopeo-inspect" fetch_inspect
@@ -98,7 +98,6 @@ spec:
             fetch_variant() {
               skopeo --override-os "${os}" --override-arch "${arch}" inspect --no-tags \
                 docker://"${name}@${digest}" \
-                --authfile=/tekton/creds/.docker/config.json \
                 > "$(workspaces.data.path)/$os/$arch/skopeo.json"
             }
             retry "skopeo-inspect-${os}-${arch}" fetch_variant
@@ -121,6 +120,8 @@ spec:
           name: shared
         - mountPath: /opt/otel
           name: otel-helpers
+        - mountPath: /tekton/creds/.docker
+          name: docker-config
 
     - name: generate
       image: "{{ .Values.task.agent.image }}:{{ .Values.task.agent.tag | default .Chart.AppVersion }}"
@@ -149,6 +150,8 @@ spec:
           value: "$(params.retry-max-delay)"
         - name: SYFT_LOG_LEVEL
           value: "info"
+        - name: DOCKER_CONFIG
+          value: "/tekton/creds/.docker"
       script: |
         #!/usr/bin/env bash
         set -Eeuo pipefail
@@ -179,6 +182,8 @@ spec:
           name: shared
         - mountPath: /opt/otel
           name: otel-helpers
+        - mountPath: /tekton/creds/.docker
+          name: docker-config
 
     - name: upload
       image: "{{ .Values.task.agent.image }}:{{ .Values.task.agent.tag | default .Chart.AppVersion }}"
@@ -268,3 +273,13 @@ spec:
     - name: otel-helpers
       configMap:
         name: {{ .Release.Name }}-otel-helpers
+    - name: docker-config
+      {{- if .Values.task.registryAuth.enabled }}
+      secret:
+        secretName: {{ .Values.task.registryAuth.secretName }}
+        items:
+          - key: .dockerconfigjson
+            path: config.json
+      {{- else }}
+      emptyDir: { }
+      {{- end }}

--- a/helm/syft-generator-chart/values.yaml
+++ b/helm/syft-generator-chart/values.yaml
@@ -80,6 +80,12 @@ task:
     # If tag is empty, the template will default to .Chart.AppVersion (The Git SHA)
     tag: ""
     pullPolicy: IfNotPresent
+  # Authentication Credentials for image registries
+  registryAuth:
+    # Enable mounting a custom dockerconfigjson secret
+    enabled: false
+    # The name of the kubernetes.io/dockerconfigjson secret in the same namespace
+    secretName: "syft-image-registry-credentials"
 
 # This is for setting Kubernetes Annotations to a Pod.
 # For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/


### PR DESCRIPTION
I have implemented a way to configure docker credentials by pointing to a dockerconfig json secret in Helm where it then gets mounted to the taskrun for image registry authentication

In our deployment there would need to be:
- A secret already created
- registryAuth enabled in Helm values
- secret referenced in Helm values

My minikube is broken so I have not yet been able to test this