### PR TITLE
Include check for oci image manifest v1 for single images

### DIFF
--- a/helm/syft-generator-chart/templates/tekton/syft-generation-task.yaml
+++ b/helm/syft-generator-chart/templates/tekton/syft-generation-task.yaml
@@ -102,7 +102,7 @@ spec:
             }
             retry "skopeo-inspect-${os}-${arch}" fetch_variant
           done
-        elif jq -e "(if .mediaType == \"application/vnd.docker.distribution.manifest.v2+json\" then 1 else null end)" $(workspaces.data.path)/raw.json > /dev/null; then
+        elif jq -e "(if .mediaType == \"application/vnd.docker.distribution.manifest.v2+json\" or .mediaType == \"application/vnd.oci.image.manifest.v1+json\" then 1 else null end)" $(workspaces.data.path)/raw.json > /dev/null; then
             # Single image logic
             os=$(jq -cr '.Os' $(workspaces.data.path)/image.json)
             arch=$(jq -cr '.Architecture' $(workspaces.data.path)/image.json)


### PR DESCRIPTION
A bug fix for a format check for single image, that exists in the classic code but somehow got lost during the port to the new tekton task. This should allow support for this manifest format